### PR TITLE
add rate-limit to prevent DOS attacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,14 @@
 const express       = require('express')
 const bodyParser    = require('body-parser')
-
+const rateLimit     = require("express-rate-limit")
 // OWN FILES
 const userRoute     = require('./routes/user')
 const dbconnection  = require('./db/db')
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, //Limit to 100 each IP adres
+  message: "Teveel request vanaf dit adres. Voor dev: verander in index.js het max aantal in const limiter"
+})
 
 // Make connection to the database
 dbconnection()
@@ -12,6 +17,7 @@ express()
     .use('/static', express.static('static'))
     .use(bodyParser.urlencoded({extended: true}))
     .use(bodyParser.json())
+    .use(limiter)
     // Set view engine to ejs and let it search in the folder views
     .set('view engine', 'ejs')
     .set('views', 'views')

--- a/package-lock.json
+++ b/package-lock.json
@@ -599,6 +599,11 @@
         }
       }
     },
+    "express-rate-limit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.1.1.tgz",
+      "integrity": "sha512-puA1zcCx/quwWUOU6pT6daCt6t7SweD9wKChKhb+KSgFMKRwS81C224hiSAUANw/gnSHiwEhgozM/2ezEBZPeA=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^8.2.0",
     "ejs": "^3.0.1",
     "express": "^4.17.1",
+    "express-rate-limit": "^5.1.1",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.9.5",
     "multer": "^1.4.2"


### PR DESCRIPTION
Weer een package toegevoegd voor de veiligheid. Deze zorgt dat maximaal 100 requests mogelijk zijn per 15 minuten. 

Je kunt het checken door in index.js in de const limiter de `max:`  te veranderen naar bv. 1. Dan krijg je bij de tweede request al een melding.